### PR TITLE
Clearer internal chart names and versions

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
--
+- Internal charts: Clearer names and versions for when listed via `helm ls`
 
 ## 0.5.0 - 2022-09-06
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Internal charts: Clearer names and versions for when listed via `helm ls`
+- Internal charts: Clearer names and versions for when listed via `helm ls` (#4)
 
 ## 0.5.0 - 2022-09-06
 

--- a/src/internal-charts/application/Chart.yaml
+++ b/src/internal-charts/application/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
-name: Application
-version: "0.1.3"
+name: shipmight-application
+version: "0.0.0"

--- a/src/internal-charts/job/Chart.yaml
+++ b/src/internal-charts/job/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
-name: Job
-version: "0.1.3"
+name: shipmight-job
+version: "0.0.0"


### PR DESCRIPTION
### This PR

- adds clearer names to internal charts, e.g. `shipmight-application` and `shipmight-job`
- sets the versions of internal charts to `0.0.0`

### Background

Managing Shipmight apps via Helm CLI is not an expected usecase, but if someone lists releases for some reason…

Previously would get weird `Application-0.1.3` or `Job-0.1.3` versions when running `helm ls`:

```shell
$ helm ls -n default-project-9f6b2
NAME      	NAMESPACE            	REVISION	UPDATED                              	STATUS  	CHART            	APP VERSION
test-589d2	default-project-9f6b2	1       	2022-09-14 12:32:53.732695 +0300 EEST	deployed	Application-0.1.3
```

The weirdly specific `0.1.3` version is a relic from the past and does not actually represent the chart version. Setting the version to `0.0.0` indicates that these charts are not meant for public consumption and the version number does not matter.

Also changing the names to lowercase and more specific `shipmight-<appType>`.

Output after the change:

```shell
$ helm ls -n default-project-9f6b2
NAME      	NAMESPACE            	REVISION	UPDATED                              	STATUS  	CHART                      	APP VERSION
test-589d2	default-project-9f6b2	2       	2022-09-14 12:34:16.166365 +0300 EEST	deployed	shipmight-application-0.0.0
```